### PR TITLE
feat: #27 DevCorsConfig 구현

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/GatewayApplication.java
+++ b/src/main/java/com/nhnacademy/illuwa/GatewayApplication.java
@@ -7,9 +7,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @SpringBootApplication
 @EnableFeignClients
 public class GatewayApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(GatewayApplication.class, args);
     }
-
 }

--- a/src/main/java/com/nhnacademy/illuwa/config/DevCorsConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/config/DevCorsConfig.java
@@ -1,0 +1,28 @@
+package com.nhnacademy.illuwa.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class DevCorsConfig {
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true); // 쿠키 허용
+        config.addAllowedOrigin(frontendUrl); // 프론트 주소 -> (운영환경) 도메인 주소 "https://book1lluwa.store"
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsWebFilter(source);
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/filter/JwtValidationFilter.java
+++ b/src/main/java/com/nhnacademy/illuwa/filter/JwtValidationFilter.java
@@ -33,7 +33,9 @@ public class JwtValidationFilter implements GlobalFilter {
     // 인증 제외(Path 화이트리스트)
     private static final List<String> WHITE_LIST = List.of(
             "/api/auth", "/api/login", "/api/signup", "/static", "/actuator", "/api/books", "/api/order/guest/order-history",
-            "/api/members/check-status"
+            "/api/members/check-status",
+            "/api/members/inactive/verification",
+            "/api/members/inactive/verification/verify"
     );
 
     @Override


### PR DESCRIPTION
## 📝작업 내용
### **한 줄 요약: "js로 타 도메인 api 호출 할 수 있게 함"**

1. front 휴면회원 인증 페이지에서 복잡한 페이지 이동 없이 한 페이지내에서 구현하기 위해 js fetch를 사용함
-  휴면회원은 인증해제 전까지 jwt 토큰 발급 안해줄거라서 gateway와 front의 여러 설정을 허용해주었으나
-  api가 정상호출되지 않는 이슈

2. 우리가 설정한 jwt나 security 말고도 브라우저 단에서 막아주는 보안설정이 있는 걸 알게됨 "CORS"
CORS는 Cross-Origin Resource Sharing의 약자로, 
웹 페이지에서 다른 출처(도메인, 프로토콜, 포트)의 리소스에 접근할 수 있도록 허용하는 보안 메커니즘

(쉽게 말해 브라우저 단에서 gateway를 통한 user-service를 접근하려고 했기 때문에 브라우저가 차단함)

3. 이에 js에서 다른 서비스로 (다른 포트번호) 보내는 요청을 허용해주도록 하는 DevCorsConfig 구현
해당 프론트주소에서 오는 요청을 허용한다 라는 개념 
(이때 프론트주소는 ${frontend.url} 로 config-repo에 관리 - dev에선 localhost:10300, prod에선 우리 도메인주소)

4. [중요🚨] 이를 적용하더라도 여전히 gateway의 filter나 front의 security Config는 문제없이 정상작동한다.
js로 api 요청할 길을 열어준 것 뿐

5. 배포 후에 한번 더 설정을 점검할 필요가 있음

## 💬리뷰 요구사항
참고자료: https://docs.tosspayments.com/resources/glossary/cors
기존: 프론트 → 백엔드 → FeignClient → 다른 서버 | 프록시 방식 | ❌ (브라우저는 모름)
js fetch : 프론트 js가 외부 도메인 호출       CORS 응답 헤더 방식 | ✅ (브라우저가 차단함)

저게 아니고서는 방법을 못 찾아서 혹시 더 보안을 강화하는 측면의 방법이 있다면 적극반영하고 싶습니다
편하게 피드백해주십셔 감사합니다 🫡

## Issue Tag
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #27
